### PR TITLE
HollisterCo scraper

### DIFF
--- a/run/urls.yml
+++ b/run/urls.yml
@@ -1,5 +1,31 @@
-spartina449: # add . to the provider name to skip all its urls
+.spartina449: # add . to the provider name to skip all its urls
   - https://www.spartina449.com/lowcountry-pearl-necklace-silver-atlantic-opal.html
-_4ocean:
+._4ocean:
   # - https://www.4ocean.com/products/hammerhead-shark-beaded-bracelet
   - https://www.4ocean.com/products/4ocean-logo-womens-v-neck-long-sleeve-t-shirt
+hollisterco:
+  - https://www.abercrombie.com/shop/wd/p/straight-jeans-35504840?seq=02&categoryId=12236&faceout=prod1
+  - https://www.hollisterco.com/shop/wd/social-tourist/p/social-tourist-dog-leash-45662320?categoryId=65014738&seq=01
+  - https://www.hollisterco.com/shop/wd/gilly-hicks/p/gilly-hicks-dreamworthy-soft-square-neck-loungelette-44676819?categoryId=64790790&seq=01&faceout=life1
+  - https://www.hollisterco.com/shop/wd/p/must-have-crewneck-t-shirt-45785819?categoryId=12634&seq=07&faceout=prod1
+  - https://www.hollisterco.com/shop/wd/gilly-hicks/p/gilly-hicks-go-seamless-plunge-sportlette-45354820?categoryId=64790382&seq=03
+  - https://www.hollisterco.com/shop/wd/p/ultra-high-rise-dad-jeans-46301003?categoryId=12620&seq=01
+  - https://www.hollisterco.com/shop/wd/p/must-have-wrap-baby-tee-45989821?categoryId=12552&seq=02&faceout=prod1
+  - https://www.hollisterco.com/shop/wd/p/skinny-fleece-jogger-pants-46540325?categoryId=12556&seq=01&faceout=life1
+  - https://www.hollisterco.com/shop/wd/p/super-skinny-jeans-46299079?categoryId=12589&seq=10&faceout=model1
+  - https://www.hollisterco.com/shop/wd/p/flash-reactive-stacked-skinny-no-fade-jeans-45992478?categoryId=12589&seq=09&faceout=prod1
+  - https://www.hollisterco.com/shop/wd/p/ankle-socks-5-pack-38321322?categoryId=16409&seq=01&faceout=prod1
+  - https://www.hollisterco.com/shop/wd/social-tourist/p/social-tourist-baggy-jeans-44495321?categoryId=12623&seq=01&faceout=life1
+  - https://www.hollisterco.com/shop/wd/p/must-have-polo-2-pack-43608819?categoryId=671151&seq=07&faceout=prod1
+  - https://www.hollisterco.com/shop/wd/gilly-hicks/p/gilly-hicks-go-breathe-full-zip-46205821?categoryId=64790718&seq=01&faceout=model1
+  - https://www.hollisterco.com/shop/wd/gilly-hicks/p/gilly-hicks-waffle-joggers-46564819?categoryId=64790717&seq=03&faceout=model1
+  - https://www.hollisterco.com/shop/wd/gilly-hicks/p/gilly-hicks-happy-fleece-short-46564820?categoryId=64790717&seq=01&faceout=model1
+  - https://www.hollisterco.com/shop/wd/gilly-hicks/p/gilly-hicks-happy-fleece-short-46564820?categoryId=64790717&seq=03&faceout=prod1
+  - https://www.hollisterco.com/shop/wd-es/p/print-graphic-tee-43946320-1002?categoryId=63058424&seq=02&faceout=prod1
+  # - https://www.hollisterco.com/shop/wd-es/p/pride-print-bandana-44245819-1002?categoryId=63058424&seq=01&faceout=prod1
+  # - https://www.hollisterco.com/shop/wd-es/p/paquete-de-5-camisetas-con-cuello-redondo-infaltable-45822820?categoryId=12634&seq=01&faceout=prod1
+  # - https://www.hollisterco.com/shop/wd-es/p/tie-dye-graphic-tank-43946820-1002?categoryId=63058424&seq=01&faceout=prod1
+  # - https://www.hollisterco.com/shop/wd-es/p/colonia-jake-44781821?categoryId=16403&seq=02&faceout=prod2
+  # - https://www.hollisterco.com/shop/wd-es/p/jeans-ajustados-hollister-7503122-1002?categoryId=12589&seq=06&faceout=model1
+  # - https://www.hollisterco.com/shop/wd-es/p/tie-dye-icon-slide-sandal-45387319-1002?categoryId=16409&seq=01&faceout=prod1
+  # - https://www.hollisterco.com/shop/wd-es/gilly-hicks/p/gilly-hicks-go-seamless-plunge-sportlette-45354820-1002?categoryId=63189722&seq=03&faceout=prod1

--- a/src/providers/hollisterco/index.ts
+++ b/src/providers/hollisterco/index.ts
@@ -1,0 +1,3 @@
+export const name = 'hollisterco'
+
+export { default as scraper } from './scraper'

--- a/src/providers/hollisterco/scraper.ts
+++ b/src/providers/hollisterco/scraper.ts
@@ -1,0 +1,173 @@
+import Product from '../../entities/product'
+import Scraper from '../../interfaces/scraper'
+import screenPage from '../../utils/capture'
+
+const scraper: Scraper = async (request, page) => {
+  page.setUserAgent(
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.75 Safari/537.36',
+  )
+
+  let itemGroupUrl = request.pageUrl
+  let itemGroupId = request.pageUrl.split('?')[0].split('-').slice(-1)[0]
+
+  await page.goto(request.pageUrl)
+
+  const title = await page.$eval('.product-title-main-header', e => e.textContent?.trim() || '')
+  const subtitle = await page.$eval('.short-description', e => e.textContent?.trim() || '')
+  const currency = await page.$eval(
+    '.open-currency-selection-modal span',
+    e => e.textContent?.split(/\(|\)/g)[1] || '',
+  )
+  //@ts-ignore
+  const breadcrumbs = await page.$eval('.breadcrumbs ol', e => e.innerText.split('\n') || '')
+
+  const options = await page.evaluate(() => {
+
+    let options = Array.prototype.map.call(
+      document.querySelectorAll('select[name="sku"] option'),
+      el => ({
+        idx: el.value,
+        ...Object.assign({}, el.dataset),
+      }),
+    )
+
+    // if more than one option remove the first empty tag
+    options = options.length === 1 ? options : options.slice(1)
+
+    let swatch
+    let onlyOneAvailable = false
+
+    // @ts-ignore
+    if (document.querySelector('.product-swatches li').length > 1) {
+      swatch = Array.prototype.map.call(
+        document.querySelectorAll('.product-swatches input'),
+        el => ({
+          ...Object.assign({}, el.dataset),
+        }),
+      )
+    } else {
+      // @ts-ignore
+      onlyOneAvailable = options.find(o => o.inventoryStatus === 'Available').swatch
+      swatch = [
+        {
+          // @ts-ignore
+          productid: Object.keys(productCatalog)[0],
+          swatch: onlyOneAvailable,
+          producturl: null,
+        },
+      ]
+    }
+
+    swatch = swatch.map(sw => {
+      //@ts-ignore
+      const p = productCatalog[sw.productid]
+      const kv = p.productAttrsComplex.FiberContent
+      const keyValues = {}
+
+      if (kv !== undefined) {
+        // check for .value (str) or .values []
+        if (kv.value) {
+          let [key, value] = kv.value.split(':')
+          keyValues[key] = value
+        } else {
+          //@ts-ignore
+          for (let pairs of p.productAttrsComplex.FiberContent.values) {
+            let [key, value] = pairs.value.split(':')
+            keyValues[key] = value
+          }
+        }
+      }
+
+      let bullets = p.productAttrsComplex.CareInstructions?.values.map(o => o.value)
+      bullets = Array.isArray(bullets) ? bullets : []
+
+      const tmp = document.createElement("DIV");
+      tmp.innerHTML = p.longDesc;
+
+      const plainTextDescription = tmp.textContent || tmp.innerText || "";
+
+      return {
+        //@ts-ignore
+        ...sw,
+        sizeChartUrls: [
+          `https://www.hollisterco.com/api/ecomm/h-wd/product/sizeguide/${p.sizeChartName}`,
+        ],
+        description: plainTextDescription,
+        keyValuePairs: keyValues,
+        bullets: bullets,
+        //@ts-ignore
+        images: Object.values(productCatalog[sw.productid].imageSets)
+          .flat()
+          //@ts-ignore
+          .filter(o => o.id)
+          //@ts-ignore
+          .map(o => `https://img.hollisterco.com/is/image/anf/${o.id}?policy=product-large`),
+      }
+    })
+
+    options = options
+      .filter((op: any) => !onlyOneAvailable || op.swatch === onlyOneAvailable)
+      .map((op: any) => ({
+        ...op,
+        ...swatch.find(s => s.swatch === op.swatch),
+      }))
+
+    options = options.map((op: any) => {
+      //@ts-ignore
+      let item: any = Object.values(productPrices[op.productid].items)[0]
+      return {
+        ...op,
+        ...item,
+      }
+    })
+
+    return options
+
+  })
+
+  const variants = options.map((op: any) => ({
+    ...op,
+    producturl:
+      op.producturl === null ? itemGroupUrl : new URL(itemGroupUrl).hostname + op.producturl,
+  }))
+
+  // console.dir(variants, { depth: null })
+
+  const products = variants.map((v: any) => {
+    let p = new Product(`${v.idx}-${v.productid}`, title, v.producturl)
+
+    p.subTitle = subtitle
+    p.images = v.images
+    p.videos = []
+    p.description = v.description
+    p.currency = currency
+    p.sku = v.sku
+    p.brand = v.brand
+    p.size = v.sizePrimary + (v.sizeSecondary ? ` - ${v.sizeSecondary}` : '')
+    p.realPrice = v.offerPrice || v.listPrice
+    p.higherPrice = v.listPrice
+    p.availability = v.inventoryStatus === 'Available'
+    p.itemGroupId = itemGroupId
+    p.color = v.swatchColorFamily
+    p.colorFamily = v.swatch
+    p.bullets = v.bullets
+    p.keyValuePairs = v.keyValuePairs
+    p.sizeChartUrls = v.sizeChartUrls
+
+    return p
+  })
+
+  const screenshot = await screenPage(page)
+
+  // the site fingerprints the browser with cookies on the first request
+  const client = await page.target().createCDPSession()
+  await client.send('Network.clearBrowserCookies')
+  await client.send('Network.clearBrowserCache')
+
+  return {
+    screenshot,
+    products,
+  }
+}
+
+export default scraper

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -5,6 +5,7 @@ import IProvider from '../interfaces/provider'
  */
 export * as _4ocean from './4ocean'
 export * as spartina449 from './spartina449'
+export * as hollisterco from './hollisterco'
 
 export function getProvider(name: string) {
   const provider: IProvider = exports[name]


### PR DESCRIPTION
Pasé los datos que solo derivo de selectores a llamadas más atómicas con $eval.
Adentro del evaluate quedó bastante lógica relacionada con objectos del scope window.
La descripción ahora es texto plano y algunos otros fixes.

También funciona con URLs de Abercombie, y los 2 sub-shops de HollisterCo